### PR TITLE
Update GraphQL query schema for new slippi api

### DIFF
--- a/cron/slippi.ts
+++ b/cron/slippi.ts
@@ -1,43 +1,48 @@
 import { RateLimiter } from "limiter"
 
 export const getPlayerData = async (connectCode: string) => {
-  const query = `fragment userProfilePage on User {
-    displayName
-    connectCode {
-          code
-          __typename
-        }
-      rankedNetplayProfile {
-            id
-            ratingOrdinal
-            ratingUpdateCount
-            wins
-            losses
-            dailyGlobalPlacement
-            dailyRegionalPlacement
-            continent
-            characters {
-                    id
-                    character
-                    gameCount
-                    __typename
-                  }
-            __typename
-          }
+  const query = `fragment profileFieldsV2 on NetplayProfileV2 {
+    id
+    ratingOrdinal
+    ratingUpdateCount
+    wins
+    losses
+    dailyGlobalPlacement
+    dailyRegionalPlacement
+    continent
+    characters {
+      character
+      gameCount
       __typename
+    }
+    __typename
   }
 
+  fragment userProfilePage on User {
+    fbUid
+    displayName
+    connectCode {
+      code
+      __typename
+    }
+    rankedNetplayProfile {
+      ...profileFieldsV2
+      __typename
+    }
+    __typename
+  }
+    
   query AccountManagementPageQuery($cc: String!) {
-      getConnectCode(code: $cc) {
-            user {
-                    ...userProfilePage
-                    __typename
-                  }
-            __typename
-          }
+    getConnectCode(code: $cc) {
+      user {
+        ...userProfilePage
+        __typename
+      }
+      __typename
+    }
   }`;
 
-  const req = await fetch('https://gql-gateway-dot-slippi.uc.r.appspot.com/graphql', {
+  const req = await fetch('https://gql-gateway-2-dot-slippi.uc.r.appspot.com/graphql', {
     headers: {
       'content-type': 'application/json',
     },


### PR DESCRIPTION
Pointing to the new `https://gql-gateway-2-dot-slippi.uc.r.appspot.com/graphql` URI and updating the query to match the new schema.